### PR TITLE
Enables Cross Article Links

### DIFF
--- a/wiki_service/linkHelper.py
+++ b/wiki_service/linkHelper.py
@@ -21,7 +21,7 @@ def searchContentForLinks(content: str) -> List[Tuple]:
     searchString = "siehe "
     # +6 because "siehe " has 6 characters
     startIndexes = [m.start() + 6 for m in re.finditer(searchString, content)]
-    indexesOfOccurences = []
+    indexesOfReferences = []
     for startIndex in startIndexes:
         # reference is in the beginning/middle of the content
         if len(content) > startIndex + MAX_LENGTH_OF_TITLE:
@@ -32,8 +32,8 @@ def searchContentForLinks(content: str) -> List[Tuple]:
 
         refArticleLength = searchSection.find(")")
         endIndex = startIndex + refArticleLength
-        indexesOfOccurences.append(tuple((startIndex, endIndex)))
-    return indexesOfOccurences
+        indexesOfReferences.append(tuple((startIndex, endIndex)))
+    return indexesOfReferences
 
 
 def addLinks(content: str, indexesOfReferences: List[Tuple], titleToID: Dict) -> str:

--- a/wiki_service/linkHelper.py
+++ b/wiki_service/linkHelper.py
@@ -1,0 +1,63 @@
+from typing import Dict, List
+from .wikiEntry import MAX_LENGTH_OF_TITLE
+from pymongo import CursorType
+import re
+
+# currently 57 (see validator in wikiEntry.py)
+LEN_OF_SEARCH_SECTION = MAX_LENGTH_OF_TITLE + 7
+
+
+def createTitleToIdDict(entries: CursorType) -> Dict:
+    titleToID = {}
+    for article in entries:
+        print(article)
+        titleToID[article.get("title")] = str(article.get("_id"))
+    return titleToID
+
+
+def checkIfLinksHaveToBeAdded(paragraph: Dict) -> List:
+    contentString = paragraph.get("text")
+    print(type(contentString))
+    searchString = "siehe "
+    print(type(searchString))
+    indexesOfOccurences = [m.start() for m in re.finditer(searchString, contentString)]
+    return indexesOfOccurences
+
+
+def addLinks(paragraph: Dict, indexesOfOccurences: List, titleToID: Dict) -> Dict:
+    updatedParagraph = {}
+    contentString = paragraph.get("text")
+    # stores the point, until the original text has already been stored again
+    progressStoredTextIndex = 0
+
+    for i, indexOfOccurence in enumerate(indexesOfOccurences):
+
+        # reference is in the middle of the content
+        if len(contentString) > indexOfOccurence + LEN_OF_SEARCH_SECTION:
+            searchSection = contentString[indexOfOccurence:indexOfOccurence + LEN_OF_SEARCH_SECTION]
+        # reference is at the end of the content
+        else:
+            searchSection = contentString[indexOfOccurence:len(contentString) - 1]
+
+        print(searchSection)
+        indexEndOfRefArticle = searchSection.find(")")
+        # shortens the searchSection ("siehe ABC-Modell). Man kann sie sich") to "ABC-Modell"
+        refArticleName = searchSection[6:indexEndOfRefArticle]
+        print(refArticleName)
+        refArticleID = titleToID.get(refArticleName)
+        newTextKey = "text" + str(i)
+        updatedParagraph[newTextKey] = contentString[progressStoredTextIndex:indexOfOccurence + 5]
+
+        # set progress to the ")" after the article title
+        progressStoredTextIndex = indexOfOccurence + indexEndOfRefArticle
+
+        newLinkKey = "link" + str(i)
+        updatedParagraph[newLinkKey] = {
+            "refArticleName": refArticleName,
+            "refArticleID": refArticleID
+        }
+        if i == len(indexesOfOccurences) - 1:
+            newTextKey = "text" + str(i + 1)
+            updatedParagraph[newTextKey] = contentString[progressStoredTextIndex:len(contentString)]
+
+    return updatedParagraph

--- a/wiki_service/linkHelper.py
+++ b/wiki_service/linkHelper.py
@@ -10,16 +10,13 @@ LEN_OF_SEARCH_SECTION = MAX_LENGTH_OF_TITLE + 7
 def createTitleToIdDict(entries: CursorType) -> Dict:
     titleToID = {}
     for article in entries:
-        print(article)
         titleToID[article.get("title")] = str(article.get("_id"))
     return titleToID
 
 
 def checkIfLinksHaveToBeAdded(paragraph: Dict) -> List:
     contentString = paragraph.get("text")
-    print(type(contentString))
     searchString = "siehe "
-    print(type(searchString))
     indexesOfOccurences = [m.start() for m in re.finditer(searchString, contentString)]
     return indexesOfOccurences
 
@@ -39,11 +36,9 @@ def addLinks(paragraph: Dict, indexesOfOccurences: List, titleToID: Dict) -> Dic
         else:
             searchSection = contentString[indexOfOccurence:len(contentString) - 1]
 
-        print(searchSection)
         indexEndOfRefArticle = searchSection.find(")")
         # shortens the searchSection ("siehe ABC-Modell). Man kann sie sich") to "ABC-Modell"
         refArticleName = searchSection[6:indexEndOfRefArticle]
-        print(refArticleName)
         refArticleID = titleToID.get(refArticleName)
         newTextKey = "text" + str(i)
         updatedParagraph[newTextKey] = contentString[progressStoredTextIndex:indexOfOccurence + 5]

--- a/wiki_service/linkHelper.py
+++ b/wiki_service/linkHelper.py
@@ -7,7 +7,9 @@ import re
 def createTitleToIdDict(entries: CursorType) -> Dict:
     titleToID = {}
     for article in entries:
-        titleToID[article.get("title")] = str(article.get("_id"))
+        newKey = article.get("title").strip().lower()
+        titleToID[newKey] = str(article.get("_id"))
+    print(titleToID)
     return titleToID
 
 
@@ -43,10 +45,16 @@ def addLinks(content: str, indexesOfReferences: List[Tuple], titleToID: Dict) ->
 
         # assemble link
         refArticleName = content[startIndex:endIndex]
-        refArticleID = titleToID.get(refArticleName)
+        refArticleID = titleToID.get(refArticleName.strip().lower())
         markDownLink = "[{}] (kopfsachen:wiki/{})".format(refArticleName, refArticleID)
 
         # replace article title with link
         content = content[:startIndex] + markDownLink + content[endIndex:]
+        # since the link extends the content, the indexes have to be adjusted
+        for i in range(len(indexesOfReferences) - 1):
+            lenOfReference = endIndex - startIndex
+            increment = len(markDownLink) - lenOfReference
+            newIndex = tuple((indexesOfReferences[i+1][0] + increment, indexesOfReferences[i+1][1] + increment))
+            indexesOfReferences[i+1] = newIndex
 
     return content

--- a/wiki_service/mongoAPI.py
+++ b/wiki_service/mongoAPI.py
@@ -83,7 +83,9 @@ class MongoAPI:
                 article["content"] = updatedContent
 
                 # update changed article in the DB
-                query = {"_id": ObjectId(titleToID.get(article.get("title")))}
+                currentArticleName = article.get("title").strip().lower()
+                currentArticleID = ObjectId(titleToID.get(currentArticleName))
+                query = {"_id": currentArticleID}
                 newValues = {"$set": {"content": article.get("content")}}
                 responseUpdate = self.collection.update_one(query, newValues)
                 if responseUpdate.matched_count == 0:

--- a/wiki_service/mongoAPI.py
+++ b/wiki_service/mongoAPI.py
@@ -4,7 +4,7 @@ from urllib.parse import quote_plus
 from os import getenv
 from http import HTTPStatus
 import logging as log
-from .linkHelper import addLinks, createTitleToIdDict, checkIfLinksHaveToBeAdded
+from .linkHelper import addLinks, createTitleToIdDict, searchContentForLinks
 
 
 class MongoAPI:
@@ -67,31 +67,21 @@ class MongoAPI:
         # 3. create cross article links
         # fetch all articles from DB and create dict to get the ID by article title
         cursor = self.collection.find({})
-        if cursor.count() == 0:
-            return {
-                "status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
-                "error": "Could not find any articles in DB"
-            }
         titleToID = createTitleToIdDict(cursor)
 
         # update all articles where links are intended
         for article in data:
-            articleWasUpdated = False
-            for iParagraph, paragraph in enumerate(article.get("content")):
-                # in case it is an image link
-                if "text" not in paragraph:
-                    continue
 
-                # get the indexes of the occurences of the substring "siehe " in a paragraph
-                indexesOfTitleOccurences = checkIfLinksHaveToBeAdded(paragraph)
+            # get the position of the intended references in the content
+            # e.g. [(4, 10), (20, 28)]
+            indexesOfRefOccurences = searchContentForLinks(article.get("content"))
 
-                if len(indexesOfTitleOccurences) > 0:
-                    # replace existing paragraph in the content list of an article with a new one
-                    updatedParagraph = addLinks(paragraph, indexesOfTitleOccurences, titleToID)
-                    article.get("content")[iParagraph] = updatedParagraph
-                    articleWasUpdated = True
+            if len(indexesOfRefOccurences) > 0:
 
-            if articleWasUpdated:
+                # replace the content with a linkified one
+                updatedContent = addLinks(article.get("content"), indexesOfRefOccurences, titleToID)
+                article["content"] = updatedContent
+
                 # update changed article in the DB
                 query = {"_id": ObjectId(titleToID.get(article.get("title")))}
                 newValues = {"$set": {"content": article.get("content")}}
@@ -99,7 +89,7 @@ class MongoAPI:
                 if responseUpdate.matched_count == 0:
                     return {
                         "status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
-                        "error": "Modified Article could not be updated in DB"
+                        "error": "Linkified Article could not be updated in DB"
                     }
 
         return {

--- a/wiki_service/mongoAPI.py
+++ b/wiki_service/mongoAPI.py
@@ -101,7 +101,6 @@ class MongoAPI:
                         "status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
                         "error": "Modified Article could not be updated in DB"
                     }
-        print(data)
 
         return {
             "status_code": HTTPStatus.OK,

--- a/wiki_service/mongoAPI.py
+++ b/wiki_service/mongoAPI.py
@@ -74,12 +74,12 @@ class MongoAPI:
 
             # get the position of the intended references in the content
             # e.g. [(4, 10), (20, 28)]
-            indexesOfRefOccurences = searchContentForLinks(article.get("content"))
+            indexesOfReferences = searchContentForLinks(article.get("content"))
 
-            if len(indexesOfRefOccurences) > 0:
+            if len(indexesOfReferences) > 0:
 
                 # replace the content with a linkified one
-                updatedContent = addLinks(article.get("content"), indexesOfRefOccurences, titleToID)
+                updatedContent = addLinks(article.get("content"), indexesOfReferences, titleToID)
                 article["content"] = updatedContent
 
                 # update changed article in the DB

--- a/wiki_service/wikiEntry.py
+++ b/wiki_service/wikiEntry.py
@@ -2,6 +2,8 @@ from pydantic import BaseModel, validator
 from typing import List
 # import datetime
 
+MAX_LENGTH_OF_TITLE = 50
+
 
 class wikiEntry(BaseModel):
     title: str
@@ -12,10 +14,10 @@ class wikiEntry(BaseModel):
     # tags: List[str]
 
     @validator('title')
-    # title must be a string with a length of 5-50 characters
+    # title must be a string with a length of 5-30 characters
     def title_validator(cls, v):
-        if len(v) < 3 or len(v) > 50:
-            raise ValueError('the title must have a length between 3 and 50')
+        if len(v) < 3 or len(v) > MAX_LENGTH_OF_TITLE:
+            raise ValueError('the title must have a length between 3 and {}'.format(MAX_LENGTH_OF_TITLE))
         return v.title()
 
     @validator('content')

--- a/wiki_service/wikiEntry.py
+++ b/wiki_service/wikiEntry.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel, validator
-from typing import List
 # import datetime
 
 MAX_LENGTH_OF_TITLE = 50
@@ -7,7 +6,7 @@ MAX_LENGTH_OF_TITLE = 50
 
 class wikiEntry(BaseModel):
     title: str
-    content: List[dict]
+    content: str
 
     # TODO: add more attributes in future versions
     # date: datetime.date
@@ -24,10 +23,7 @@ class wikiEntry(BaseModel):
     # must be a string with at least 20 characters
     def content_validator(cls, v):
         if len(v) < 1:
-            raise ValueError('the content list must be longer than 0')
-        for paragraph in v:
-            if len(paragraph.get("text")) == 0:
-                raise ValueError('the content must have at least 1 character')
+            raise ValueError('the content must be longer than 0 characters')
         return v
 
     """

--- a/wiki_service/wikiEntry.py
+++ b/wiki_service/wikiEntry.py
@@ -14,7 +14,7 @@ class wikiEntry(BaseModel):
     # tags: List[str]
 
     @validator('title')
-    # title must be a string with a length of 5-30 characters
+    # title must be a string with a length of 5-50 characters
     def title_validator(cls, v):
         if len(v) < 3 or len(v) > MAX_LENGTH_OF_TITLE:
             raise ValueError('the title must have a length between 3 and {}'.format(MAX_LENGTH_OF_TITLE))


### PR DESCRIPTION
This PR introduces the following features/fixes:

- another datatype can now be stored within a paragraph: **LINKS**. They provide the name of the referenced article and the ID of the referenced article
- Fixes #19 
- makes Validation more understandable/ dev friendly (introduces a contant for the max. title length)